### PR TITLE
Money error indictator

### DIFF
--- a/src/Main/GameScreen.java
+++ b/src/Main/GameScreen.java
@@ -573,6 +573,7 @@ public class GameScreen extends javax.swing.JFrame {
     private void Update(float time) {
         updatePlots(time);
         updateMoneyLabel();
+        
         displayTime(time);
         
         // If 10 minutes have passed, forcibly end the game.
@@ -632,7 +633,7 @@ public class GameScreen extends javax.swing.JFrame {
     }
     
     private void displayTime(float time){
-        System.out.println(time);
+        //System.out.println(time); //Debug get rid of display time spam
         if (!UITime.getText().equals(Timer.GetTimeAsString())){
             UITime.setText("<html>"
                             + "<div style='text-align: center;'>"

--- a/src/Main/UITile.form
+++ b/src/Main/UITile.form
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
-<Form version="1.3" maxVersion="1.9" type="org.netbeans.modules.form.forminfo.JPanelFormInfo">
+<Form version="1.9" maxVersion="1.9" type="org.netbeans.modules.form.forminfo.JPanelFormInfo">
   <Properties>
     <Property name="maximumSize" type="java.awt.Dimension" editor="org.netbeans.beaninfo.editors.DimensionEditor">
       <Dimension value="[75, 75]"/>
@@ -28,24 +28,76 @@
   <Layout>
     <DimensionLayout dim="0">
       <Group type="103" groupAlignment="0" attributes="0">
-          <Component id="CenterLabel" pref="75" max="32767" attributes="0"/>
           <Group type="102" attributes="0">
               <Component id="seedProgressBar" min="-2" pref="67" max="-2" attributes="0"/>
-              <EmptySpace min="0" pref="0" max="32767" attributes="0"/>
+              <EmptySpace pref="8" max="32767" attributes="0"/>
+          </Group>
+          <Group type="103" rootIndex="1" groupAlignment="0" attributes="0">
+              <Group type="102" alignment="1" attributes="0">
+                  <EmptySpace max="32767" attributes="0"/>
+                  <Component id="ErrorPane" min="-2" max="-2" attributes="0"/>
+                  <EmptySpace pref="-47" max="32767" attributes="0"/>
+              </Group>
+          </Group>
+          <Group type="103" rootIndex="2" groupAlignment="0" attributes="0">
+              <Group type="102" alignment="0" attributes="0">
+                  <Component id="CenterLabel" min="-2" pref="69" max="-2" attributes="0"/>
+                  <EmptySpace min="0" pref="6" max="32767" attributes="0"/>
+              </Group>
           </Group>
       </Group>
     </DimensionLayout>
     <DimensionLayout dim="1">
       <Group type="103" groupAlignment="0" attributes="0">
-          <Group type="102" alignment="0" attributes="0">
-              <Component id="CenterLabel" min="-2" pref="58" max="-2" attributes="0"/>
-              <EmptySpace max="-2" attributes="0"/>
-              <Component id="seedProgressBar" pref="11" max="32767" attributes="0"/>
+          <Group type="102" attributes="0">
+              <EmptySpace min="-2" pref="64" max="-2" attributes="0"/>
+              <Component id="seedProgressBar" pref="25" max="32767" attributes="0"/>
+          </Group>
+          <Group type="103" rootIndex="1" groupAlignment="0" attributes="0">
+              <Group type="102" alignment="1" attributes="0">
+                  <EmptySpace max="32767" attributes="0"/>
+                  <Component id="ErrorPane" min="-2" max="-2" attributes="0"/>
+                  <EmptySpace max="32767" attributes="0"/>
+              </Group>
+          </Group>
+          <Group type="103" rootIndex="2" groupAlignment="0" attributes="0">
+              <Group type="102" alignment="0" attributes="0">
+                  <Component id="CenterLabel" min="-2" pref="64" max="-2" attributes="0"/>
+                  <EmptySpace min="0" pref="25" max="32767" attributes="0"/>
+              </Group>
           </Group>
       </Group>
     </DimensionLayout>
   </Layout>
   <SubComponents>
+    <Container class="javax.swing.JLayeredPane" name="ErrorPane">
+
+      <Layout>
+        <DimensionLayout dim="0">
+          <Group type="103" groupAlignment="0" attributes="0">
+              <Group type="102" alignment="0" attributes="0">
+                  <Component id="ErrorText" min="-2" pref="62" max="-2" attributes="0"/>
+                  <EmptySpace min="0" pref="54" max="32767" attributes="0"/>
+              </Group>
+          </Group>
+        </DimensionLayout>
+        <DimensionLayout dim="1">
+          <Group type="103" groupAlignment="0" attributes="0">
+              <Group type="102" alignment="0" attributes="0">
+                  <Component id="ErrorText" min="-2" pref="53" max="-2" attributes="0"/>
+                  <EmptySpace min="0" pref="24" max="32767" attributes="0"/>
+              </Group>
+          </Group>
+        </DimensionLayout>
+      </Layout>
+      <SubComponents>
+        <Component class="javax.swing.JLabel" name="ErrorText">
+          <Properties>
+            <Property name="focusable" type="boolean" value="false"/>
+          </Properties>
+        </Component>
+      </SubComponents>
+    </Container>
     <Component class="javax.swing.JLabel" name="CenterLabel">
       <Properties>
         <Property name="font" type="java.awt.Font" editor="org.netbeans.beaninfo.editors.FontEditor">

--- a/src/Main/UITile.form
+++ b/src/Main/UITile.form
@@ -36,13 +36,13 @@
               <Group type="102" alignment="1" attributes="0">
                   <EmptySpace max="32767" attributes="0"/>
                   <Component id="ErrorPane" min="-2" max="-2" attributes="0"/>
-                  <EmptySpace pref="-47" max="32767" attributes="0"/>
+                  <EmptySpace max="32767" attributes="0"/>
               </Group>
           </Group>
           <Group type="103" rootIndex="2" groupAlignment="0" attributes="0">
               <Group type="102" alignment="0" attributes="0">
-                  <Component id="CenterLabel" min="-2" pref="69" max="-2" attributes="0"/>
-                  <EmptySpace min="0" pref="6" max="32767" attributes="0"/>
+                  <Component id="CenterLabel" min="-2" pref="75" max="-2" attributes="0"/>
+                  <EmptySpace min="0" pref="0" max="32767" attributes="0"/>
               </Group>
           </Group>
       </Group>
@@ -62,8 +62,8 @@
           </Group>
           <Group type="103" rootIndex="2" groupAlignment="0" attributes="0">
               <Group type="102" alignment="0" attributes="0">
-                  <Component id="CenterLabel" min="-2" pref="64" max="-2" attributes="0"/>
-                  <EmptySpace min="0" pref="25" max="32767" attributes="0"/>
+                  <Component id="CenterLabel" min="-2" pref="58" max="-2" attributes="0"/>
+                  <EmptySpace min="0" pref="31" max="32767" attributes="0"/>
               </Group>
           </Group>
       </Group>
@@ -76,8 +76,8 @@
         <DimensionLayout dim="0">
           <Group type="103" groupAlignment="0" attributes="0">
               <Group type="102" alignment="0" attributes="0">
-                  <Component id="ErrorText" min="-2" pref="62" max="-2" attributes="0"/>
-                  <EmptySpace min="0" pref="54" max="32767" attributes="0"/>
+                  <Component id="ErrorText" min="-2" pref="75" max="-2" attributes="0"/>
+                  <EmptySpace min="0" pref="41" max="32767" attributes="0"/>
               </Group>
           </Group>
         </DimensionLayout>

--- a/src/Main/UITile.java
+++ b/src/Main/UITile.java
@@ -86,8 +86,8 @@ public class UITile extends javax.swing.JPanel {
         ErrorPaneLayout.setHorizontalGroup(
             ErrorPaneLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
             .addGroup(ErrorPaneLayout.createSequentialGroup()
-                .addComponent(ErrorText, javax.swing.GroupLayout.PREFERRED_SIZE, 62, javax.swing.GroupLayout.PREFERRED_SIZE)
-                .addGap(0, 54, Short.MAX_VALUE))
+                .addComponent(ErrorText, javax.swing.GroupLayout.PREFERRED_SIZE, 75, javax.swing.GroupLayout.PREFERRED_SIZE)
+                .addGap(0, 41, Short.MAX_VALUE))
         );
         ErrorPaneLayout.setVerticalGroup(
             ErrorPaneLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
@@ -123,8 +123,8 @@ public class UITile extends javax.swing.JPanel {
                     .addContainerGap(javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)))
             .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
                 .addGroup(layout.createSequentialGroup()
-                    .addComponent(CenterLabel, javax.swing.GroupLayout.PREFERRED_SIZE, 69, javax.swing.GroupLayout.PREFERRED_SIZE)
-                    .addGap(0, 6, Short.MAX_VALUE)))
+                    .addComponent(CenterLabel, javax.swing.GroupLayout.PREFERRED_SIZE, 75, javax.swing.GroupLayout.PREFERRED_SIZE)
+                    .addGap(0, 0, Short.MAX_VALUE)))
         );
         layout.setVerticalGroup(
             layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
@@ -138,8 +138,8 @@ public class UITile extends javax.swing.JPanel {
                     .addContainerGap(javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)))
             .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
                 .addGroup(layout.createSequentialGroup()
-                    .addComponent(CenterLabel, javax.swing.GroupLayout.PREFERRED_SIZE, 64, javax.swing.GroupLayout.PREFERRED_SIZE)
-                    .addGap(0, 25, Short.MAX_VALUE)))
+                    .addComponent(CenterLabel, javax.swing.GroupLayout.PREFERRED_SIZE, 58, javax.swing.GroupLayout.PREFERRED_SIZE)
+                    .addGap(0, 31, Short.MAX_VALUE)))
         );
     }// </editor-fold>//GEN-END:initComponents
 

--- a/src/Main/UITile.java
+++ b/src/Main/UITile.java
@@ -1,7 +1,7 @@
 package Main;
 import java.awt.event.MouseAdapter;
 import javax.swing.ImageIcon;
-
+import javax.swing.JLabel;
 
 /*
  * Click nbfs://nbhost/SystemFileSystem/Templates/Licenses/license-default.txt to change this license
@@ -26,16 +26,19 @@ public class UITile extends javax.swing.JPanel {
         ImageIcon NoSeed = new ImageIcon("src/Images/EmptyTile.png");
         CenterLabel.setIcon(NoSeed);
         
+        
         BorderHandler borderhandler = new BorderHandler();
         CenterLabel.addMouseListener(new MouseAdapter(){
             @Override
             public void mouseEntered(java.awt.event.MouseEvent evt){
                 borderhandler.showBorder((UITile) CenterLabel.getParent(), "#ff8066", 1);
                 
+                
             } 
             @Override
             public void mouseExited(java.awt.event.MouseEvent evt){
                 borderhandler.hideBorder((UITile) CenterLabel.getParent());
+                setErrorText(""); //Reset whatever error was previously shown.
             }
             
         });
@@ -64,6 +67,8 @@ public class UITile extends javax.swing.JPanel {
     // <editor-fold defaultstate="collapsed" desc="Generated Code">//GEN-BEGIN:initComponents
     private void initComponents() {
 
+        ErrorPane = new javax.swing.JLayeredPane();
+        ErrorText = new javax.swing.JLabel();
         CenterLabel = new javax.swing.JLabel();
         seedProgressBar = new javax.swing.JProgressBar();
 
@@ -71,6 +76,25 @@ public class UITile extends javax.swing.JPanel {
         setMinimumSize(new java.awt.Dimension(75, 75));
         setName(""); // NOI18N
         setPreferredSize(new java.awt.Dimension(75, 75));
+
+        ErrorText.setFocusable(false);
+
+        ErrorPane.setLayer(ErrorText, javax.swing.JLayeredPane.DEFAULT_LAYER);
+
+        javax.swing.GroupLayout ErrorPaneLayout = new javax.swing.GroupLayout(ErrorPane);
+        ErrorPane.setLayout(ErrorPaneLayout);
+        ErrorPaneLayout.setHorizontalGroup(
+            ErrorPaneLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+            .addGroup(ErrorPaneLayout.createSequentialGroup()
+                .addComponent(ErrorText, javax.swing.GroupLayout.PREFERRED_SIZE, 62, javax.swing.GroupLayout.PREFERRED_SIZE)
+                .addGap(0, 54, Short.MAX_VALUE))
+        );
+        ErrorPaneLayout.setVerticalGroup(
+            ErrorPaneLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+            .addGroup(ErrorPaneLayout.createSequentialGroup()
+                .addComponent(ErrorText, javax.swing.GroupLayout.PREFERRED_SIZE, 53, javax.swing.GroupLayout.PREFERRED_SIZE)
+                .addGap(0, 24, Short.MAX_VALUE))
+        );
 
         CenterLabel.setFont(new java.awt.Font("Segoe UI", 0, 8)); // NOI18N
         CenterLabel.setText("jLabel1");
@@ -89,17 +113,33 @@ public class UITile extends javax.swing.JPanel {
         this.setLayout(layout);
         layout.setHorizontalGroup(
             layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-            .addComponent(CenterLabel, javax.swing.GroupLayout.DEFAULT_SIZE, 75, Short.MAX_VALUE)
             .addGroup(layout.createSequentialGroup()
                 .addComponent(seedProgressBar, javax.swing.GroupLayout.PREFERRED_SIZE, 67, javax.swing.GroupLayout.PREFERRED_SIZE)
-                .addGap(0, 0, Short.MAX_VALUE))
+                .addContainerGap(8, Short.MAX_VALUE))
+            .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+                .addGroup(javax.swing.GroupLayout.Alignment.TRAILING, layout.createSequentialGroup()
+                    .addContainerGap(javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
+                    .addComponent(ErrorPane, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                    .addContainerGap(javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)))
+            .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+                .addGroup(layout.createSequentialGroup()
+                    .addComponent(CenterLabel, javax.swing.GroupLayout.PREFERRED_SIZE, 69, javax.swing.GroupLayout.PREFERRED_SIZE)
+                    .addGap(0, 6, Short.MAX_VALUE)))
         );
         layout.setVerticalGroup(
             layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
             .addGroup(layout.createSequentialGroup()
-                .addComponent(CenterLabel, javax.swing.GroupLayout.PREFERRED_SIZE, 58, javax.swing.GroupLayout.PREFERRED_SIZE)
-                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                .addComponent(seedProgressBar, javax.swing.GroupLayout.PREFERRED_SIZE, 11, Short.MAX_VALUE))
+                .addGap(64, 64, 64)
+                .addComponent(seedProgressBar, javax.swing.GroupLayout.DEFAULT_SIZE, 25, Short.MAX_VALUE))
+            .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+                .addGroup(javax.swing.GroupLayout.Alignment.TRAILING, layout.createSequentialGroup()
+                    .addContainerGap(javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
+                    .addComponent(ErrorPane, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                    .addContainerGap(javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)))
+            .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+                .addGroup(layout.createSequentialGroup()
+                    .addComponent(CenterLabel, javax.swing.GroupLayout.PREFERRED_SIZE, 64, javax.swing.GroupLayout.PREFERRED_SIZE)
+                    .addGap(0, 25, Short.MAX_VALUE)))
         );
     }// </editor-fold>//GEN-END:initComponents
 
@@ -110,8 +150,18 @@ public class UITile extends javax.swing.JPanel {
             //if player has enough money
             PlantSeed();
         }
+        else //player doesn't have enough money
+        {
+            System.out.println("UITile:Not enough money!");
+            setErrorText("No Money!");
+        }
     }//GEN-LAST:event_CenterLabelMouseReleased
 
+    private void setErrorText(String text)
+    {
+        ErrorText.setText(text);
+    }
+    
     //When the text is clicked, do what?
     private void CenterLabelMouseClicked(java.awt.event.MouseEvent evt) {//GEN-FIRST:event_CenterLabelMouseClicked
            
@@ -164,7 +214,6 @@ public class UITile extends javax.swing.JPanel {
     private void updateProgressBar(float time)
     {
         float percent;
-        
         //Note: progress bar is between 0 and 100%, so set value should be from 0 to 100
         if (tile.getGrowthStage() == 2){ // decrease progress bar when fully grown
             percent = 100 - (tile.calcDifference(time) / Constants.Seeds.get(tile.getCurrentSeed()).GetTime() * 100);
@@ -214,6 +263,8 @@ public class UITile extends javax.swing.JPanel {
    
     // Variables declaration - do not modify//GEN-BEGIN:variables
     private javax.swing.JLabel CenterLabel;
+    private javax.swing.JLayeredPane ErrorPane;
+    private javax.swing.JLabel ErrorText;
     private javax.swing.JProgressBar seedProgressBar;
     // End of variables declaration//GEN-END:variables
 }


### PR DESCRIPTION
Adds text over tile informing user they don't have enough money if they try to plant without enough money. When the mouse stops hovering over the tile, then the text dissappears. All of this is handled in the setErrorText function.